### PR TITLE
Update IGDBWrapper.swift

### DIFF
--- a/Sources/IGDB-SWIFT-API/Wrapper/IGDBWrapper.swift
+++ b/Sources/IGDB-SWIFT-API/Wrapper/IGDBWrapper.swift
@@ -9,12 +9,15 @@
 import Foundation
 import Just
 
-private let APIURL = "https://api.igdb.com/v4"
+private var APIURL = "https://api.igdb.com/v4"
 
 public class IGDBWrapper {
     private var requestHeaders = ["x-user-agent": "igdb-api-swift"]
     public init(clientID: String, accessToken: String) {
         requestHeaders = ["x-user-agent": "igdb-api-swift", "client-id": clientID, "authorization": "Bearer \(accessToken)"]
+    }
+    public init(proxyURL: String) {
+        APIURL = proxyURL
     }
     
     public func apiProtoRequest(endpoint: Endpoint, apicalypseQuery: String, dataResponse: @escaping (Data) -> (Void), errorResponse: @escaping (RequestException) -> (Void)) {


### PR DESCRIPTION
Add ability to init the wrapper using a proxy URL.

I setup a proxy server per the [IGDB API doc guidelines](https://api-docs.igdb.com/?swift#proxy). This change lets you use the proxy URL and not expose your Twitch OAuth2.0 client id or client secret in the code.